### PR TITLE
Fix starting debug PSTN call

### DIFF
--- a/app/backend/Services/CallAutomationService.cs
+++ b/app/backend/Services/CallAutomationService.cs
@@ -134,7 +134,7 @@ namespace CustomerSupportServiceSample.Services
             {
                 // 5. For better OpenAI results, include complete conversation history to query
                 // Using the original chat thread ID that was stored to OperationContext
-                List<ChatHistory> chatHistory = await GetFormattedChatHistory(threadId: recognizeCompleted.OperationContext!);
+                List<ChatHistory>? chatHistory = await GetFormattedChatHistory(threadId: recognizeCompleted.OperationContext!);
 
                 var chatGPTResponse = await openAIService.AnswerAsync(speech_result, chatHistory);
 
@@ -217,6 +217,10 @@ namespace CustomerSupportServiceSample.Services
         private async Task<List<ChatHistory>> GetFormattedChatHistory(string threadId)
         {
             var botUserId = cacheService.GetCache("BotUserId");
+            if (string.IsNullOrEmpty(threadId) || string.IsNullOrEmpty(botUserId))
+            {
+                return null;
+            }
             var botToken = await identityService.GetTokenForUserId(botUserId);
 
             var chatClient = new ChatClient(

--- a/app/backend/Services/TranscriptionService.cs
+++ b/app/backend/Services/TranscriptionService.cs
@@ -22,6 +22,10 @@ namespace CustomerSupportServiceSample.Services
             string text,
             string displayName)
         {
+            if (string.IsNullOrEmpty(threadId) || string.IsNullOrEmpty(userId))
+            {
+                return;
+            }
             // Retrieve user access token to be able to post the message on behalf of user
             var userToken = await identityService.GetTokenForUserId(userId);
 

--- a/app/backend/appsettings.json
+++ b/app/backend/appsettings.json
@@ -9,7 +9,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Information"
+      "Microsoft.AspNetCore": "Warning"
     }
   },
   "AllowedHosts": "*",
@@ -17,8 +17,7 @@
   "AcsSettings": {
     "AcsConnectionString": "",
     "AcsEndpoint": "",
-    "AcsPhoneNumber": "",
-    "CallbackApiEndpointForCall": ""
+    "AcsPhoneNumber": ""
   },
   "AcsEmailSettings": {
     "Sender": "",
@@ -27,8 +26,7 @@
   "OpenAISettings": {
     "OpenAIEndpoint": "",
     "OpenAIKey": "",
-    "OpenAIDeploymentName": "",
-    "OpenAIModelName": ""
+    "OpenAIDeploymentName": ""
   },
   "CognitiveServiceSettings": {
     "CognitiveSearchEndpoint": "",


### PR DESCRIPTION
The /api/debug endpoint starts a standalone call without corresponding chat thread. Transcribe feature and chat history won't be available. Ignore them gracefully.

+ remove unnecessary configuration values